### PR TITLE
add HuggingFace service including VLM capability

### DIFF
--- a/backend/app/api/rag.py
+++ b/backend/app/api/rag.py
@@ -33,6 +33,11 @@ def _get_llm_info(config: dict) -> dict:
             "provider": "google",
             "model": llm_cfg.get("google_model", "gemini-2.5-flash"),
         }
+    if provider == "huggingface":
+        return {
+            "provider": "huggingface",
+            "model": llm_cfg.get("hf_model", settings.hf_text_model),
+        }
     return {"provider": "local", "model": llm_cfg.get("model", "")}
 
 
@@ -64,6 +69,16 @@ def _get_llm_service(config: dict):
             )
         model = llm_cfg.get("google_model", "gemini-2.5-flash")
         return GoogleService(api_key=api_key, model=model)
+
+    if provider == "huggingface":
+        from app.services.huggingface_service import HuggingFaceService
+
+        return HuggingFaceService(
+            model_id=llm_cfg.get("hf_model", settings.hf_text_model),
+            embedding_model_id=llm_cfg.get(
+                "hf_embedding_model", settings.hf_embedding_model
+            ),
+        )
 
     # Default: local Ollama
     return OllamaService(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -17,6 +17,9 @@ class Settings(BaseSettings):
     anthropic_api_key: str | None = None
     google_api_key: str | None = None
     prompts_dir: str = "/app/prompts"
+    hf_text_model: str = "Qwen/Qwen2.5-3B-Instruct"
+    hf_embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2"
+    hf_vlm_model: str = "Qwen/Qwen2-VL-2B-Instruct"
 
 
 def load_config(config_path: str = "config.yaml") -> dict:

--- a/backend/app/services/huggingface_service.py
+++ b/backend/app/services/huggingface_service.py
@@ -1,0 +1,265 @@
+"""HuggingFace Transformers LLM and multimodal service.
+
+Provides text generation, dense embeddings, and vision-language model (VLM)
+inference using locally loaded HuggingFace models. All models are lazily
+loaded on first use and cached for subsequent calls.
+
+Install optional dependencies before use:
+    uv sync --extra huggingface
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import PIL.Image
+
+logger = logging.getLogger(__name__)
+
+
+class HuggingFaceService:
+    """LLM, embedding, and multimodal service via HuggingFace Transformers.
+
+    All three capabilities (text generation, embeddings, VLM) share a single
+    service instance. Models are loaded lazily on first use and kept in memory.
+
+    Args:
+        model_id: HuggingFace model ID for text generation.
+        embedding_model_id: HuggingFace model ID for dense embeddings.
+        vlm_model_id: HuggingFace model ID for vision-language inference.
+            Required only when calling ``generate_multimodal`` or
+            ``extract_from_image``.
+    """
+
+    def __init__(
+        self,
+        model_id: str = "Qwen/Qwen2.5-3B-Instruct",
+        embedding_model_id: str = "sentence-transformers/all-MiniLM-L6-v2",
+        vlm_model_id: str | None = None,
+    ) -> None:
+        self.model_id = model_id
+        self.embedding_model_id = embedding_model_id
+        self.vlm_model_id = vlm_model_id
+
+        # Lazy-loaded — populated on first use
+        self._text_pipe = None
+        self._embed_tokenizer = None
+        self._embed_model = None
+        self._vlm_pipe = None
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Internal helpers
+    # ──────────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _get_device() -> str:
+        """Return the best available device: CUDA > MPS (Apple Silicon) > CPU."""
+        import torch
+
+        if torch.cuda.is_available():
+            return "cuda"
+        if torch.backends.mps.is_available():
+            return "mps"
+        return "cpu"
+
+    def _get_text_pipe(self):
+        if self._text_pipe is None:
+            from transformers import pipeline
+
+            logger.info("Loading text-generation model: %s", self.model_id)
+            self._text_pipe = pipeline(
+                "text-generation",
+                model=self.model_id,
+                device=self._get_device(),
+                torch_dtype="auto",
+            )
+        return self._text_pipe
+
+    def _get_embed_model(self):
+        if self._embed_model is None:
+            from transformers import AutoModel, AutoTokenizer
+
+            logger.info("Loading embedding model: %s", self.embedding_model_id)
+            self._embed_tokenizer = AutoTokenizer.from_pretrained(
+                self.embedding_model_id
+            )
+            self._embed_model = AutoModel.from_pretrained(
+                self.embedding_model_id,
+                torch_dtype="auto",
+            ).to(self._get_device())
+            self._embed_model.eval()
+        return self._embed_tokenizer, self._embed_model
+
+    def _get_vlm_pipe(self):
+        if self._vlm_pipe is None:
+            if not self.vlm_model_id:
+                raise ValueError(
+                    "vlm_model_id is not set. Pass a VLM model ID to HuggingFaceService "
+                    "to use multimodal capabilities."
+                )
+            from transformers import pipeline
+
+            logger.info("Loading vision-language model: %s", self.vlm_model_id)
+            self._vlm_pipe = pipeline(
+                "image-text-to-text",
+                model=self.vlm_model_id,
+                device=self._get_device(),
+                torch_dtype="auto",
+            )
+        return self._vlm_pipe
+
+    @staticmethod
+    def _mean_pool(token_embeddings, attention_mask) -> list[float]:
+        """Mean-pool token embeddings, ignoring padding tokens, then L2-normalise."""
+        import torch
+        import torch.nn.functional as F
+
+        mask = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+        pooled = torch.sum(token_embeddings * mask, 1) / torch.clamp(
+            mask.sum(1), min=1e-9
+        )
+        normalised = F.normalize(pooled, p=2, dim=1)
+        return normalised[0].cpu().tolist()
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Text interface — mirrors OllamaService
+    # ──────────────────────────────────────────────────────────────────────
+
+    def generate(
+        self,
+        prompt: str,
+        system: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int = 512,
+    ) -> str:
+        """Generate a text response from the loaded instruction-tuned model.
+
+        Args:
+            prompt: User message.
+            system: Optional system prompt.
+            temperature: Sampling temperature (0 = greedy).
+            max_tokens: Maximum new tokens to generate.
+
+        Returns:
+            Generated text string.
+        """
+        pipe = self._get_text_pipe()
+        messages: list[dict] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        result = pipe(
+            messages,
+            max_new_tokens=max_tokens,
+            temperature=temperature,
+            do_sample=temperature > 0,
+        )
+        generated = result[0]["generated_text"]
+        # Pipeline returns the full conversation list; take the last assistant turn.
+        if isinstance(generated, list):
+            return str(generated[-1]["content"])
+        return str(generated)
+
+    def generate_embedding(self, text: str) -> list[float]:
+        """Generate a dense embedding vector for *text* via mean pooling.
+
+        Args:
+            text: Input text to embed.
+
+        Returns:
+            L2-normalised embedding as a list of floats.
+        """
+        import torch
+
+        tokenizer, model = self._get_embed_model()
+        encoded = tokenizer(text, padding=True, truncation=True, return_tensors="pt")
+        device = next(model.parameters()).device
+        encoded = {k: v.to(device) for k, v in encoded.items()}
+
+        with torch.no_grad():
+            outputs = model(**encoded)
+
+        return self._mean_pool(outputs.last_hidden_state, encoded["attention_mask"])
+
+    def generate_embeddings_batch(self, texts: list[str]) -> list[list[float]]:
+        """Generate embeddings for multiple texts.
+
+        Args:
+            texts: List of input strings.
+
+        Returns:
+            List of embedding vectors.
+        """
+        return [self.generate_embedding(t) for t in texts]
+
+    def check_health(self) -> bool:
+        """Return True if the text model loads without error."""
+        try:
+            self._get_text_pipe()
+            return True
+        except Exception:
+            return False
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Multimodal interface — VLM
+    # ──────────────────────────────────────────────────────────────────────
+
+    def generate_multimodal(
+        self,
+        prompt: str,
+        images: list[PIL.Image.Image],
+        system: str | None = None,
+        max_tokens: int = 1024,
+    ) -> str:
+        """Generate a response from a VLM given text and one or more images.
+
+        Args:
+            prompt: User text prompt.
+            images: List of PIL Image objects to include in the request.
+            system: Optional system prompt.
+            max_tokens: Maximum tokens to generate.
+
+        Returns:
+            Generated text response.
+        """
+        pipe = self._get_vlm_pipe()
+
+        content: list[dict] = [{"type": "image", "image": img} for img in images]
+        content.append({"type": "text", "text": prompt})
+
+        messages: list[dict] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": content})
+
+        result = pipe(messages, max_new_tokens=max_tokens)
+        generated = result[0]["generated_text"]
+        if isinstance(generated, list):
+            return str(generated[-1]["content"])
+        return str(generated)
+
+    def extract_from_image(
+        self,
+        image: PIL.Image.Image,
+        prompt: str = (
+            "Extract all text content from this image exactly as it appears. "
+            "Preserve headings, paragraphs, lists, and tables using Markdown formatting. "
+            "Do not add commentary — output only the extracted content."
+        ),
+    ) -> str:
+        """Run OCR-like text extraction on a single image using the VLM.
+
+        Suitable for scanned PDFs, figures with embedded text, or any image
+        where layout-based converters (Docling, PyMuPDF) are insufficient.
+
+        Args:
+            image: PIL Image to extract text from.
+            prompt: Extraction instruction prompt for the VLM.
+
+        Returns:
+            Extracted text in Markdown format.
+        """
+        return self.generate_multimodal(prompt=prompt, images=[image])

--- a/backend/app/services/huggingface_vlm_converter.py
+++ b/backend/app/services/huggingface_vlm_converter.py
@@ -102,7 +102,7 @@ class HuggingFaceVLMConverter:
         images = []
         for page in doc:
             pix = page.get_pixmap(matrix=mat)
-            img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+            img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
             images.append(img)
         doc.close()
         return images

--- a/backend/app/services/huggingface_vlm_converter.py
+++ b/backend/app/services/huggingface_vlm_converter.py
@@ -1,0 +1,148 @@
+"""VLM-based PDF converter backend using HuggingFace vision-language models.
+
+Converts PDFs to Markdown by rendering each page as an image and passing it
+through a VLM. Useful for scanned PDFs, image-heavy documents, or any file
+where layout-based converters (Docling, PyMuPDF4LLM) fall short.
+
+Install optional dependencies before use:
+    uv sync --extra huggingface
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from app.services.huggingface_service import HuggingFaceService
+from app.services.pdf_converter_base import register_converter
+
+logger = logging.getLogger(__name__)
+
+_EXTRACT_PROMPT = (
+    "You are a document extraction assistant. "
+    "Extract all text from this PDF page exactly as it appears. "
+    "Preserve headings, paragraphs, lists, and table structure using Markdown formatting. "
+    "Do not add commentary or summaries — output only the extracted content."
+)
+
+_METADATA_PROMPT = (
+    "Extract the following fields from this document page if present:\n"
+    "- title\n"
+    "- authors (comma-separated full names)\n"
+    "- abstract\n"
+    "- publication year (4-digit number)\n\n"
+    "Return ONLY a JSON object with keys: title, authors, abstract, year. "
+    "Use null for any field not found. Do not include any other text."
+)
+
+
+class HuggingFaceVLMConverter:
+    """PDF converter that uses a VLM to extract text from rendered page images.
+
+    Each page is rendered to a PIL Image at a configurable DPI and passed to
+    the VLM with an extraction prompt. Per-page outputs are concatenated with
+    Markdown horizontal rules as page separators.
+
+    Args:
+        vlm_service: An existing HuggingFaceService instance. If None, a new
+            one is created using *vlm_model_id*.
+        vlm_model_id: Model ID used when creating a new service instance.
+        dpi: Page render resolution. Higher DPI → better OCR quality, slower.
+    """
+
+    name: str = "vlm"
+
+    def __init__(
+        self,
+        vlm_service: HuggingFaceService | None = None,
+        vlm_model_id: str = "Qwen/Qwen2-VL-7B-Instruct",
+        dpi: int = 150,
+    ) -> None:
+        self._service = vlm_service or HuggingFaceService(vlm_model_id=vlm_model_id)
+        self.dpi = dpi
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Protocol methods (PDFConverterBackend)
+    # ──────────────────────────────────────────────────────────────────────
+
+    def convert_to_markdown(self, source_path: Path) -> str:
+        """Convert all pages of a PDF to Markdown via VLM extraction."""
+        pages = self._render_pages(source_path)
+        parts = []
+        for i, page_img in enumerate(pages):
+            logger.debug(
+                "VLM extracting page %d/%d of %s", i + 1, len(pages), source_path.name
+            )
+            text = self._service.extract_from_image(page_img, prompt=_EXTRACT_PROMPT)
+            parts.append(text)
+        return "\n\n---\n\n".join(parts)
+
+    def extract_metadata(self, source_path: Path, fallback_title: str) -> dict:
+        """Extract title, authors, abstract, and year from the first page."""
+        pages = self._render_pages(source_path)
+        if not pages:
+            return self._empty_metadata(fallback_title)
+
+        raw = self._service.extract_from_image(pages[0], prompt=_METADATA_PROMPT)
+        return self._parse_metadata_json(raw, fallback_title)
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Internal helpers
+    # ──────────────────────────────────────────────────────────────────────
+
+    def _render_pages(self, source_path: Path) -> list:
+        """Render all PDF pages to PIL Images using PyMuPDF."""
+        import fitz  # PyMuPDF — already a transitive dependency via pymupdf4llm
+        from PIL import Image
+
+        doc = fitz.open(str(source_path))
+        scale = self.dpi / 72
+        mat = fitz.Matrix(scale, scale)
+        images = []
+        for page in doc:
+            pix = page.get_pixmap(matrix=mat)
+            img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+            images.append(img)
+        doc.close()
+        return images
+
+    def _parse_metadata_json(self, raw: str, fallback_title: str) -> dict:
+        """Parse VLM JSON output into the standard metadata dict."""
+        try:
+            cleaned = (
+                raw.strip()
+                .removeprefix("```json")
+                .removeprefix("```")
+                .removesuffix("```")
+                .strip()
+            )
+            data = json.loads(cleaned)
+            authors_raw = data.get("authors") or ""
+            authors = [a.strip() for a in authors_raw.split(",") if a.strip()]
+            return {
+                "title": data.get("title") or fallback_title,
+                "authors": authors,
+                "abstract": data.get("abstract"),
+                "publication_date": str(data["year"]) if data.get("year") else None,
+            }
+        except (json.JSONDecodeError, AttributeError, KeyError):
+            logger.warning(
+                "VLM metadata extraction returned non-JSON output; using fallback title."
+            )
+            return self._empty_metadata(fallback_title)
+
+    @staticmethod
+    def _empty_metadata(fallback_title: str) -> dict:
+        return {
+            "title": fallback_title,
+            "authors": [],
+            "abstract": None,
+            "publication_date": None,
+        }
+
+
+# Register as the "vlm" backend in the converter registry.
+# Import this module to activate the registration:
+#   from app.services import huggingface_vlm_converter  # noqa: F401
+register_converter("vlm", HuggingFaceVLMConverter)

--- a/backend/app/services/ollama_vlm_converter.py
+++ b/backend/app/services/ollama_vlm_converter.py
@@ -1,0 +1,173 @@
+"""Ollama-based VLM PDF converter backend.
+
+Converts PDFs to Markdown by rendering each page as an image and passing it
+to a vision-capable Ollama model. Requires a multimodal model to be pulled
+in Ollama before use.
+
+Supported models (pull with ``ollama pull <model>``):
+    - llava:7b          — general-purpose, widely tested
+    - llava-phi3        — smaller and faster, good quality
+    - minicpm-v         — strong document and OCR understanding
+    - moondream         — very lightweight, fast
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import ollama
+
+from app.services.pdf_converter_base import register_converter
+
+logger = logging.getLogger(__name__)
+
+_EXTRACT_PROMPT = (
+    "You are a document extraction assistant. "
+    "Extract all text from this PDF page exactly as it appears. "
+    "Preserve headings, paragraphs, lists, and table structure using Markdown formatting. "
+    "Do not add commentary or summaries — output only the extracted content."
+)
+
+_METADATA_PROMPT = (
+    "Extract the following fields from this document page if present:\n"
+    "- title\n"
+    "- authors (comma-separated full names)\n"
+    "- abstract\n"
+    "- publication year (4-digit number)\n\n"
+    "Return ONLY a JSON object with keys: title, authors, abstract, year. "
+    "Use null for any field not found. Do not include any other text."
+)
+
+
+class OllamaVLMConverter:
+    """PDF converter that uses a vision-capable Ollama model to extract text.
+
+    Each PDF page is rendered to a JPEG image and passed to the Ollama model
+    via its chat API. Per-page outputs are concatenated with Markdown
+    horizontal rules as page separators.
+
+    Args:
+        url: Ollama server URL.
+        model: Vision-capable model name (must be pulled in Ollama first).
+        dpi: Page render resolution. Higher DPI improves OCR quality but
+            increases image size and inference time.
+    """
+
+    name: str = "ollama_vlm"
+
+    def __init__(
+        self,
+        url: str = "http://host.docker.internal:11434",
+        model: str = "llava-phi3",
+        dpi: int = 150,
+    ) -> None:
+        self.client = ollama.Client(host=url)
+        self.model = model
+        self.dpi = dpi
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Protocol methods (PDFConverterBackend)
+    # ──────────────────────────────────────────────────────────────────────
+
+    def convert_to_markdown(self, source_path: Path) -> str:
+        """Convert all pages of a PDF to Markdown via Ollama VLM extraction."""
+        pages = self._render_pages(source_path)
+        parts = []
+        for i, img_bytes in enumerate(pages):
+            logger.debug(
+                "Ollama VLM extracting page %d/%d of %s",
+                i + 1,
+                len(pages),
+                source_path.name,
+            )
+            response = self.client.chat(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": _EXTRACT_PROMPT,
+                        "images": [img_bytes],
+                    }
+                ],
+            )
+            parts.append(response["message"]["content"])
+        return "\n\n---\n\n".join(parts)
+
+    def extract_metadata(self, source_path: Path, fallback_title: str) -> dict:
+        """Extract title, authors, abstract, and year from the first page."""
+        pages = self._render_pages(source_path)
+        if not pages:
+            return self._empty_metadata(fallback_title)
+
+        response = self.client.chat(
+            model=self.model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": _METADATA_PROMPT,
+                    "images": [pages[0]],
+                }
+            ],
+        )
+        raw = response["message"]["content"]
+        return self._parse_metadata_json(raw, fallback_title)
+
+    # ──────────────────────────────────────────────────────────────────────
+    # Internal helpers
+    # ──────────────────────────────────────────────────────────────────────
+
+    def _render_pages(self, source_path: Path) -> list[bytes]:
+        """Render all PDF pages to JPEG bytes using PyMuPDF."""
+        import fitz  # PyMuPDF — already a transitive dependency via pymupdf4llm
+
+        doc = fitz.open(str(source_path))
+        scale = self.dpi / 72
+        mat = fitz.Matrix(scale, scale)
+        images = []
+        for page in doc:
+            pix = page.get_pixmap(matrix=mat)
+            images.append(pix.tobytes("jpeg"))
+        doc.close()
+        return images
+
+    def _parse_metadata_json(self, raw: str, fallback_title: str) -> dict:
+        """Parse the model's JSON output into the standard metadata dict."""
+        try:
+            cleaned = (
+                raw.strip()
+                .removeprefix("```json")
+                .removeprefix("```")
+                .removesuffix("```")
+                .strip()
+            )
+            data = json.loads(cleaned)
+            authors_raw = data.get("authors") or ""
+            authors = [a.strip() for a in authors_raw.split(",") if a.strip()]
+            return {
+                "title": data.get("title") or fallback_title,
+                "authors": authors,
+                "abstract": data.get("abstract"),
+                "publication_date": str(data["year"]) if data.get("year") else None,
+            }
+        except (json.JSONDecodeError, AttributeError, KeyError):
+            logger.warning(
+                "Ollama VLM metadata extraction returned non-JSON; using fallback title."
+            )
+            return self._empty_metadata(fallback_title)
+
+    @staticmethod
+    def _empty_metadata(fallback_title: str) -> dict:
+        return {
+            "title": fallback_title,
+            "authors": [],
+            "abstract": None,
+            "publication_date": None,
+        }
+
+
+# Register as the "ollama_vlm" backend in the converter registry.
+# Import this module to activate the registration:
+#   from app.services import ollama_vlm_converter  # noqa: F401
+register_converter("ollama_vlm", OllamaVLMConverter)

--- a/docs/HF-models-recommended.md
+++ b/docs/HF-models-recommended.md
@@ -1,0 +1,95 @@
+# HuggingFace Model Recommendations
+
+Reference guide for selecting models to use with `HuggingFaceService` and `HuggingFaceVLMConverter`.
+
+---
+
+## Text Generation
+
+Models for `hf_model` / `HuggingFaceService(model_id=...)`.
+
+| Model | Size | Notes |
+|---|---|---|
+| `Qwen/Qwen2.5-3B-Instruct` | 3B | **Recommended default.** Fast on Apple Silicon and low-VRAM GPUs. |
+| `Qwen/Qwen2.5-7B-Instruct` | 7B | Higher quality; needs ≥16GB VRAM (or 24GB unified memory). |
+| `mistralai/Mistral-7B-Instruct-v0.3` | 7B | Strong general-purpose, Apache 2.0 licence. |
+| `meta-llama/Llama-3.2-3B-Instruct` | 3B | Fast, compact; requires HF token (accept Meta licence). |
+| `meta-llama/Llama-3.1-8B-Instruct` | 8B | Higher quality; requires HF token. |
+| `google/gemma-2-9b-it` | 9B | Competitive quality; requires HF token (accept Google licence). |
+
+---
+
+## Embeddings
+
+Models for `hf_embedding_model` / `HuggingFaceService(embedding_model_id=...)`.
+
+| Model | Dimensions | Notes |
+|---|---|---|
+| `sentence-transformers/all-MiniLM-L6-v2` | 384 | **Recommended default.** Fast, small, widely used. |
+| `sentence-transformers/all-mpnet-base-v2` | 768 | Better quality, heavier. Same dimensions as Ollama `nomic-embed-text`. |
+| `BAAI/bge-small-en-v1.5` | 384 | High performance for retrieval tasks. |
+| `BAAI/bge-base-en-v1.5` | 768 | Stronger version of the above. |
+| `thenlper/gte-large` | 1024 | High quality; larger vectors mean larger Qdrant collections. |
+
+> **Important:** The embedding model determines the vector dimension stored in Qdrant.
+> Changing it on an existing collection requires re-ingesting all papers.
+> The Qdrant `get_vector_size()` check will catch mismatches at ingest time.
+
+---
+
+## Vision-Language Models (VLM)
+
+Models for `hf_vlm_model` / `HuggingFaceService(vlm_model_id=...)` and `HuggingFaceVLMConverter`.
+
+| Model | Size | Notes |
+|---|---|---|
+| `Qwen/Qwen2-VL-2B-Instruct` | 2B | **Recommended default.** Fast on Apple Silicon and low-VRAM GPUs. |
+| `Qwen/Qwen2-VL-7B-Instruct` | 7B | Higher quality OCR; needs ≥16GB VRAM. |
+| `llava-hf/llava-1.5-7b-hf` | 7B | Solid general-purpose VLM. |
+| `llava-hf/llava-1.5-13b-hf` | 13B | Higher quality, needs ~26GB VRAM. |
+| `microsoft/Phi-3.5-vision-instruct` | 4B | Compact multimodal from Microsoft, permissive licence. |
+| `google/paligemma-3b-mix-224` | 3B | Requires HF token (accept Google licence). |
+
+### Specialised OCR models
+
+For pure OCR (no conversational interface needed):
+
+| Model | Notes |
+|---|---|
+| `microsoft/trocr-base-printed` | Fast printed-text OCR via `image-to-text` pipeline. |
+| `microsoft/trocr-large-printed` | Higher accuracy printed OCR. |
+| `microsoft/trocr-base-handwritten` | Handwritten text recognition. |
+| `naver-clova-ix/donut-base` | Document understanding without OCR; structured extraction. |
+
+---
+
+## Hardware Guidance
+
+| Setup | Recommended configuration |
+|---|---|
+| GPU ≥ 24GB VRAM | Any 7B model in bfloat16 (`torch_dtype="auto"`) |
+| GPU 8–16GB VRAM | 3B models, or 7B with 4-bit quantisation (`load_in_4bit=True` via bitsandbytes) |
+| CPU only | 3B models only; inference will be slow (minutes per query) |
+
+> `device_map="auto"` in `HuggingFaceService` automatically distributes across all available GPUs and falls back to CPU.
+
+---
+
+## Switching backends in `config.yaml`
+
+```yaml
+models:
+  embedding: nomic-embed-text:latest   # still used by Ollama embeddings
+  llm:
+    type: huggingface                  # options: local | anthropic | google | huggingface
+    hf_model: Qwen/Qwen2.5-7B-Instruct
+    hf_embedding_model: sentence-transformers/all-MiniLM-L6-v2
+```
+
+Or override per-deployment via environment variables:
+
+```bash
+HF_TEXT_MODEL=Qwen/Qwen2.5-3B-Instruct
+HF_EMBEDDING_MODEL=BAAI/bge-small-en-v1.5
+HF_VLM_MODEL=Qwen/Qwen2-VL-2B-Instruct
+```

--- a/docs/HF-models-recommended.md
+++ b/docs/HF-models-recommended.md
@@ -50,7 +50,23 @@ Models for `hf_vlm_model` / `HuggingFaceService(vlm_model_id=...)` and `HuggingF
 | `microsoft/Phi-3.5-vision-instruct` | 4B | Compact multimodal from Microsoft, permissive licence. |
 | `google/paligemma-3b-mix-224` | 3B | Requires HF token (accept Google licence). |
 
-### Specialised OCR models
+---
+
+## Ollama Vision-Language Models (OllamaVLMConverter)
+
+Models for `OllamaVLMConverter(model=...)`. Pull with `ollama pull <model>` before use.
+
+| Model | Size | Notes |
+|---|---|---|
+| `llava-phi3` | 3B | **Recommended default.** Fast, good quality, runs well on Apple Silicon. |
+| `moondream` | 1.8B | Lightest option; lower quality but very fast. |
+| `llava:7b` | 7B | Stronger quality; needs ≥8GB VRAM. |
+| `llava:13b` | 13B | Best Llava quality; needs ≥16GB VRAM. |
+| `minicpm-v` | 8B | Strong document and OCR understanding. |
+
+---
+
+### Specialised OCR models (HuggingFace only)
 
 For pure OCR (no conversational interface needed):
 
@@ -71,7 +87,7 @@ For pure OCR (no conversational interface needed):
 | GPU 8–16GB VRAM | 3B models, or 7B with 4-bit quantisation (`load_in_4bit=True` via bitsandbytes) |
 | CPU only | 3B models only; inference will be slow (minutes per query) |
 
-> `device_map="auto"` in `HuggingFaceService` automatically distributes across all available GPUs and falls back to CPU.
+> `HuggingFaceService` auto-selects the best device: CUDA (Nvidia GPU) → MPS (Apple Silicon) → CPU.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,13 @@ api = [
     "anthropic>=0.18.0",
     "google-genai>=1.64.0",
 ]
+huggingface = [
+    "transformers>=4.45",
+    "torch>=2.0",
+    "accelerate>=0.27",
+    "Pillow>=10.0",
+    "sentencepiece>=0.1",
+]
 docs = [
     "sphinx>=7.0",
     "furo>=2024.1.29",

--- a/tests/unit/test_huggingface_service.py
+++ b/tests/unit/test_huggingface_service.py
@@ -15,10 +15,10 @@ sys.path.insert(0, str(backend_path))
 
 from app.services.huggingface_service import HuggingFaceService
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_service(**kwargs):
     return HuggingFaceService(
@@ -31,6 +31,7 @@ def _make_service(**kwargs):
 # ---------------------------------------------------------------------------
 # _get_device
 # ---------------------------------------------------------------------------
+
 
 def test_get_device_cuda():
     with patch("torch.cuda.is_available", return_value=True):
@@ -54,9 +55,12 @@ def test_get_device_cpu():
 # generate (text)
 # ---------------------------------------------------------------------------
 
+
 def test_generate_returns_assistant_content():
     svc = _make_service()
-    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "hello"}]}])
+    mock_pipe = Mock(
+        return_value=[{"generated_text": [{"role": "assistant", "content": "hello"}]}]
+    )
     svc._text_pipe = mock_pipe
 
     result = svc.generate(prompt="hi", system="be helpful")
@@ -71,7 +75,9 @@ def test_generate_returns_assistant_content():
 
 def test_generate_without_system():
     svc = _make_service()
-    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "ok"}]}])
+    mock_pipe = Mock(
+        return_value=[{"generated_text": [{"role": "assistant", "content": "ok"}]}]
+    )
     svc._text_pipe = mock_pipe
 
     result = svc.generate(prompt="test")
@@ -94,7 +100,9 @@ def test_generate_plain_string_output():
 
 def test_generate_passes_temperature_and_max_tokens():
     svc = _make_service()
-    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "x"}]}])
+    mock_pipe = Mock(
+        return_value=[{"generated_text": [{"role": "assistant", "content": "x"}]}]
+    )
     svc._text_pipe = mock_pipe
 
     svc.generate(prompt="hi", temperature=0.0, max_tokens=256)
@@ -109,6 +117,7 @@ def test_generate_passes_temperature_and_max_tokens():
 # generate_embedding
 # ---------------------------------------------------------------------------
 
+
 def test_generate_embedding_returns_list():
     svc = _make_service()
 
@@ -121,6 +130,7 @@ def test_generate_embedding_returns_list():
 
     # Simulate model output with last_hidden_state
     import torch
+
     fake_hidden = torch.zeros(1, 5, 384)
     fake_mask = torch.ones(1, 5)
     mock_model_output = Mock()
@@ -132,7 +142,12 @@ def test_generate_embedding_returns_list():
     svc._embed_tokenizer = mock_tokenizer
     svc._embed_model = mock_model
 
-    with patch("torch.no_grad", return_value=MagicMock(__enter__=Mock(return_value=None), __exit__=Mock(return_value=False))):
+    with patch(
+        "torch.no_grad",
+        return_value=MagicMock(
+            __enter__=Mock(return_value=None), __exit__=Mock(return_value=False)
+        ),
+    ):
         with patch.object(svc, "_mean_pool", return_value=[0.1] * 384) as mock_pool:
             result = svc.generate_embedding("test text")
 
@@ -153,6 +168,7 @@ def test_generate_embeddings_batch():
 # check_health
 # ---------------------------------------------------------------------------
 
+
 def test_check_health_true_when_pipe_loads():
     svc = _make_service()
     svc._text_pipe = Mock()  # already loaded
@@ -170,9 +186,14 @@ def test_check_health_false_when_pipe_raises():
 # generate_multimodal
 # ---------------------------------------------------------------------------
 
+
 def test_generate_multimodal_returns_content():
     svc = _make_service(vlm_model_id="test/vlm")
-    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "extracted text"}]}])
+    mock_pipe = Mock(
+        return_value=[
+            {"generated_text": [{"role": "assistant", "content": "extracted text"}]}
+        ]
+    )
     svc._vlm_pipe = mock_pipe
 
     fake_image = Mock()
@@ -184,7 +205,9 @@ def test_generate_multimodal_returns_content():
 
 def test_generate_multimodal_includes_system():
     svc = _make_service(vlm_model_id="test/vlm")
-    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "ok"}]}])
+    mock_pipe = Mock(
+        return_value=[{"generated_text": [{"role": "assistant", "content": "ok"}]}]
+    )
     svc._vlm_pipe = mock_pipe
 
     svc.generate_multimodal(prompt="p", images=[Mock()], system="sys prompt")
@@ -202,6 +225,7 @@ def test_get_vlm_pipe_raises_without_model_id():
 # ---------------------------------------------------------------------------
 # extract_from_image
 # ---------------------------------------------------------------------------
+
 
 def test_extract_from_image_calls_generate_multimodal():
     svc = _make_service(vlm_model_id="test/vlm")

--- a/tests/unit/test_huggingface_service.py
+++ b/tests/unit/test_huggingface_service.py
@@ -223,6 +223,138 @@ def test_get_vlm_pipe_raises_without_model_id():
 
 
 # ---------------------------------------------------------------------------
+# _get_text_pipe lazy loading
+# ---------------------------------------------------------------------------
+
+
+def test_get_text_pipe_lazy_loads():
+    svc = _make_service()
+    mock_pipe = Mock()
+    mock_transformers = Mock()
+    mock_transformers.pipeline.return_value = mock_pipe
+
+    with patch.dict("sys.modules", {"transformers": mock_transformers}):
+        with patch.object(HuggingFaceService, "_get_device", return_value="cpu"):
+            pipe = svc._get_text_pipe()
+
+    assert pipe is mock_pipe
+    assert svc._text_pipe is mock_pipe
+    mock_transformers.pipeline.assert_called_once_with(
+        "text-generation",
+        model="test/model",
+        device="cpu",
+        torch_dtype="auto",
+    )
+
+
+def test_get_text_pipe_cached_on_second_call():
+    svc = _make_service()
+    mock_pipe = Mock()
+    svc._text_pipe = mock_pipe
+    assert svc._get_text_pipe() is mock_pipe
+
+
+# ---------------------------------------------------------------------------
+# _get_embed_model lazy loading
+# ---------------------------------------------------------------------------
+
+
+def test_get_embed_model_lazy_loads():
+    svc = _make_service()
+    mock_tokenizer = Mock()
+    mock_model_instance = Mock()
+
+    mock_automodel = Mock()
+    mock_automodel.from_pretrained.return_value.to.return_value = mock_model_instance
+    mock_autotokenizer = Mock()
+    mock_autotokenizer.from_pretrained.return_value = mock_tokenizer
+
+    mock_transformers = Mock()
+    mock_transformers.AutoModel = mock_automodel
+    mock_transformers.AutoTokenizer = mock_autotokenizer
+
+    with patch.dict("sys.modules", {"transformers": mock_transformers}):
+        with patch.object(HuggingFaceService, "_get_device", return_value="cpu"):
+            tokenizer, model = svc._get_embed_model()
+
+    assert tokenizer is mock_tokenizer
+    assert model is mock_model_instance
+    mock_model_instance.eval.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _get_vlm_pipe lazy loading
+# ---------------------------------------------------------------------------
+
+
+def test_get_vlm_pipe_lazy_loads():
+    svc = _make_service(vlm_model_id="test/vlm")
+    mock_pipe = Mock()
+    mock_transformers = Mock()
+    mock_transformers.pipeline.return_value = mock_pipe
+
+    with patch.dict("sys.modules", {"transformers": mock_transformers}):
+        with patch.object(HuggingFaceService, "_get_device", return_value="cpu"):
+            pipe = svc._get_vlm_pipe()
+
+    assert pipe is mock_pipe
+    assert svc._vlm_pipe is mock_pipe
+    mock_transformers.pipeline.assert_called_once_with(
+        "image-text-to-text",
+        model="test/vlm",
+        device="cpu",
+        torch_dtype="auto",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _mean_pool
+# ---------------------------------------------------------------------------
+
+
+def test_mean_pool_returns_normalised_list():
+    import torch
+
+    # 1 batch, 3 tokens, 4 dims — all ones → mean = ones → L2 norm = 0.5 each
+    token_embeddings = torch.ones(1, 3, 4)
+    attention_mask = torch.ones(1, 3)
+
+    result = HuggingFaceService._mean_pool(token_embeddings, attention_mask)
+
+    assert isinstance(result, list)
+    assert len(result) == 4
+    assert abs(result[0] - 0.5) < 1e-5
+
+
+def test_mean_pool_ignores_padding_tokens():
+    import torch
+
+    # Token 3 is padding (mask=0) — result should only reflect tokens 1-2
+    token_embeddings = torch.tensor([[[1.0, 0.0], [1.0, 0.0], [99.0, 99.0]]])
+    attention_mask = torch.tensor([[1, 1, 0]])
+
+    result = HuggingFaceService._mean_pool(token_embeddings, attention_mask)
+
+    # Mean of first two tokens: [1, 0] → L2-normalised → [1, 0]
+    assert abs(result[0] - 1.0) < 1e-5
+    assert abs(result[1] - 0.0) < 1e-5
+
+
+# ---------------------------------------------------------------------------
+# generate_multimodal — plain string branch
+# ---------------------------------------------------------------------------
+
+
+def test_generate_multimodal_plain_string_output():
+    svc = _make_service(vlm_model_id="test/vlm")
+    mock_pipe = Mock(return_value=[{"generated_text": "plain text"}])
+    svc._vlm_pipe = mock_pipe
+
+    result = svc.generate_multimodal(prompt="p", images=[Mock()])
+    assert result == "plain text"
+
+
+# ---------------------------------------------------------------------------
 # extract_from_image
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_huggingface_service.py
+++ b/tests/unit/test_huggingface_service.py
@@ -1,0 +1,214 @@
+"""Unit tests for HuggingFaceService.
+
+All heavy optional dependencies (torch, transformers, PIL) are mocked so
+these tests run in the standard CI environment without GPU or extra packages.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.services.huggingface_service import HuggingFaceService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_service(**kwargs):
+    return HuggingFaceService(
+        model_id="test/model",
+        embedding_model_id="test/embed",
+        vlm_model_id=kwargs.get("vlm_model_id"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _get_device
+# ---------------------------------------------------------------------------
+
+def test_get_device_cuda():
+    with patch("torch.cuda.is_available", return_value=True):
+        with patch("torch.backends.mps.is_available", return_value=False):
+            assert HuggingFaceService._get_device() == "cuda"
+
+
+def test_get_device_mps():
+    with patch("torch.cuda.is_available", return_value=False):
+        with patch("torch.backends.mps.is_available", return_value=True):
+            assert HuggingFaceService._get_device() == "mps"
+
+
+def test_get_device_cpu():
+    with patch("torch.cuda.is_available", return_value=False):
+        with patch("torch.backends.mps.is_available", return_value=False):
+            assert HuggingFaceService._get_device() == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# generate (text)
+# ---------------------------------------------------------------------------
+
+def test_generate_returns_assistant_content():
+    svc = _make_service()
+    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "hello"}]}])
+    svc._text_pipe = mock_pipe
+
+    result = svc.generate(prompt="hi", system="be helpful")
+
+    assert result == "hello"
+    mock_pipe.assert_called_once()
+    call_args = mock_pipe.call_args
+    messages = call_args[0][0]
+    assert messages[0] == {"role": "system", "content": "be helpful"}
+    assert messages[1] == {"role": "user", "content": "hi"}
+
+
+def test_generate_without_system():
+    svc = _make_service()
+    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "ok"}]}])
+    svc._text_pipe = mock_pipe
+
+    result = svc.generate(prompt="test")
+
+    messages = mock_pipe.call_args[0][0]
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    assert result == "ok"
+
+
+def test_generate_plain_string_output():
+    """Pipeline returning a plain string (not list) is handled."""
+    svc = _make_service()
+    mock_pipe = Mock(return_value=[{"generated_text": "plain string"}])
+    svc._text_pipe = mock_pipe
+
+    result = svc.generate(prompt="hi")
+    assert result == "plain string"
+
+
+def test_generate_passes_temperature_and_max_tokens():
+    svc = _make_service()
+    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "x"}]}])
+    svc._text_pipe = mock_pipe
+
+    svc.generate(prompt="hi", temperature=0.0, max_tokens=256)
+
+    kwargs = mock_pipe.call_args[1]
+    assert kwargs["max_new_tokens"] == 256
+    assert kwargs["temperature"] == 0.0
+    assert kwargs["do_sample"] is False
+
+
+# ---------------------------------------------------------------------------
+# generate_embedding
+# ---------------------------------------------------------------------------
+
+def test_generate_embedding_returns_list():
+    svc = _make_service()
+
+    mock_tokenizer = Mock()
+    mock_tokenizer.return_value = {
+        "input_ids": MagicMock(),
+        "attention_mask": MagicMock(),
+    }
+    mock_model = Mock()
+
+    # Simulate model output with last_hidden_state
+    import torch
+    fake_hidden = torch.zeros(1, 5, 384)
+    fake_mask = torch.ones(1, 5)
+    mock_model_output = Mock()
+    mock_model_output.last_hidden_state = fake_hidden
+
+    mock_model.return_value = mock_model_output
+    mock_model.parameters.return_value = iter([torch.zeros(1)])
+
+    svc._embed_tokenizer = mock_tokenizer
+    svc._embed_model = mock_model
+
+    with patch("torch.no_grad", return_value=MagicMock(__enter__=Mock(return_value=None), __exit__=Mock(return_value=False))):
+        with patch.object(svc, "_mean_pool", return_value=[0.1] * 384) as mock_pool:
+            result = svc.generate_embedding("test text")
+
+    assert isinstance(result, list)
+    mock_pool.assert_called_once()
+
+
+def test_generate_embeddings_batch():
+    svc = _make_service()
+    with patch.object(svc, "generate_embedding", return_value=[0.1] * 384) as mock_emb:
+        results = svc.generate_embeddings_batch(["a", "b", "c"])
+
+    assert len(results) == 3
+    assert mock_emb.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# check_health
+# ---------------------------------------------------------------------------
+
+def test_check_health_true_when_pipe_loads():
+    svc = _make_service()
+    svc._text_pipe = Mock()  # already loaded
+    assert svc.check_health() is True
+
+
+def test_check_health_false_when_pipe_raises():
+    svc = _make_service()
+
+    with patch.object(svc, "_get_text_pipe", side_effect=RuntimeError("no GPU")):
+        assert svc.check_health() is False
+
+
+# ---------------------------------------------------------------------------
+# generate_multimodal
+# ---------------------------------------------------------------------------
+
+def test_generate_multimodal_returns_content():
+    svc = _make_service(vlm_model_id="test/vlm")
+    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "extracted text"}]}])
+    svc._vlm_pipe = mock_pipe
+
+    fake_image = Mock()
+    result = svc.generate_multimodal(prompt="extract text", images=[fake_image])
+
+    assert result == "extracted text"
+    mock_pipe.assert_called_once()
+
+
+def test_generate_multimodal_includes_system():
+    svc = _make_service(vlm_model_id="test/vlm")
+    mock_pipe = Mock(return_value=[{"generated_text": [{"role": "assistant", "content": "ok"}]}])
+    svc._vlm_pipe = mock_pipe
+
+    svc.generate_multimodal(prompt="p", images=[Mock()], system="sys prompt")
+
+    messages = mock_pipe.call_args[0][0]
+    assert messages[0] == {"role": "system", "content": "sys prompt"}
+
+
+def test_get_vlm_pipe_raises_without_model_id():
+    svc = HuggingFaceService(model_id="x", embedding_model_id="y", vlm_model_id=None)
+    with pytest.raises(ValueError, match="vlm_model_id is not set"):
+        svc._get_vlm_pipe()
+
+
+# ---------------------------------------------------------------------------
+# extract_from_image
+# ---------------------------------------------------------------------------
+
+def test_extract_from_image_calls_generate_multimodal():
+    svc = _make_service(vlm_model_id="test/vlm")
+    with patch.object(svc, "generate_multimodal", return_value="# Heading") as mock_gen:
+        result = svc.extract_from_image(image=Mock())
+
+    assert result == "# Heading"
+    mock_gen.assert_called_once()
+    call_kwargs = mock_gen.call_args[1]
+    assert "images" in call_kwargs

--- a/tests/unit/test_huggingface_vlm_converter.py
+++ b/tests/unit/test_huggingface_vlm_converter.py
@@ -1,0 +1,158 @@
+"""Unit tests for HuggingFaceVLMConverter.
+
+fitz (PyMuPDF) and PIL are mocked — no real PDF needed.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.services.huggingface_vlm_converter import HuggingFaceVLMConverter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_converter(pages=2):
+    """Return a converter with a mocked VLM service and patched _render_pages."""
+    mock_service = Mock()
+    conv = HuggingFaceVLMConverter(vlm_service=mock_service, dpi=72)
+    fake_images = [Mock() for _ in range(pages)]
+    conv._render_pages = Mock(return_value=fake_images)
+    return conv, mock_service, fake_images
+
+
+# ---------------------------------------------------------------------------
+# convert_to_markdown
+# ---------------------------------------------------------------------------
+
+def test_convert_to_markdown_joins_pages_with_separator():
+    conv, mock_svc, fake_imgs = _make_converter(pages=3)
+    mock_svc.extract_from_image.side_effect = ["page1", "page2", "page3"]
+
+    result = conv.convert_to_markdown(Path("/fake/paper.pdf"))
+
+    assert result == "page1\n\n---\n\npage2\n\n---\n\npage3"
+    assert mock_svc.extract_from_image.call_count == 3
+
+
+def test_convert_to_markdown_single_page():
+    conv, mock_svc, _ = _make_converter(pages=1)
+    mock_svc.extract_from_image.return_value = "only page"
+
+    result = conv.convert_to_markdown(Path("/fake/paper.pdf"))
+
+    assert result == "only page"
+
+
+def test_convert_to_markdown_passes_extract_prompt():
+    conv, mock_svc, fake_imgs = _make_converter(pages=1)
+    mock_svc.extract_from_image.return_value = "text"
+
+    conv.convert_to_markdown(Path("/fake/paper.pdf"))
+
+    call_kwargs = mock_svc.extract_from_image.call_args[1]
+    assert "prompt" in call_kwargs
+    assert "extraction" in call_kwargs["prompt"].lower() or "extract" in call_kwargs["prompt"].lower()
+
+
+# ---------------------------------------------------------------------------
+# extract_metadata
+# ---------------------------------------------------------------------------
+
+def test_extract_metadata_parses_valid_json():
+    conv, mock_svc, _ = _make_converter(pages=1)
+    mock_svc.extract_from_image.return_value = (
+        '{"title": "My Paper", "authors": "Alice, Bob", "abstract": "An abstract.", "year": 2023}'
+    )
+
+    meta = conv.extract_metadata(Path("/fake/paper.pdf"), "fallback")
+
+    assert meta["title"] == "My Paper"
+    assert "Alice" in meta["authors"]
+    assert "Bob" in meta["authors"]
+    assert meta["abstract"] == "An abstract."
+    assert meta["publication_date"] == "2023"
+
+
+def test_extract_metadata_strips_markdown_fences():
+    conv, mock_svc, _ = _make_converter(pages=1)
+    mock_svc.extract_from_image.return_value = (
+        "```json\n"
+        '{"title": "Wrapped", "authors": "Carol", "abstract": null, "year": null}\n'
+        "```"
+    )
+
+    meta = conv.extract_metadata(Path("/fake/paper.pdf"), "fallback")
+
+    assert meta["title"] == "Wrapped"
+
+
+def test_extract_metadata_falls_back_on_invalid_json():
+    conv, mock_svc, _ = _make_converter(pages=1)
+    mock_svc.extract_from_image.return_value = "not json at all"
+
+    meta = conv.extract_metadata(Path("/fake/paper.pdf"), "my_fallback")
+
+    assert meta["title"] == "my_fallback"
+    assert meta["authors"] == []
+    assert meta["abstract"] is None
+    assert meta["publication_date"] is None
+
+
+def test_extract_metadata_no_pages_returns_fallback():
+    mock_service = Mock()
+    conv = HuggingFaceVLMConverter(vlm_service=mock_service)
+    conv._render_pages = Mock(return_value=[])
+
+    meta = conv.extract_metadata(Path("/fake/empty.pdf"), "empty_fallback")
+
+    assert meta["title"] == "empty_fallback"
+    mock_service.extract_from_image.assert_not_called()
+
+
+def test_extract_metadata_null_year_gives_none():
+    conv, mock_svc, _ = _make_converter(pages=1)
+    mock_svc.extract_from_image.return_value = (
+        '{"title": "T", "authors": "", "abstract": null, "year": null}'
+    )
+
+    meta = conv.extract_metadata(Path("/fake/paper.pdf"), "fallback")
+
+    assert meta["publication_date"] is None
+
+
+# ---------------------------------------------------------------------------
+# _render_pages (mocking fitz and PIL)
+# ---------------------------------------------------------------------------
+
+def test_render_pages_returns_pil_images():
+    mock_service = Mock()
+    conv = HuggingFaceVLMConverter(vlm_service=mock_service, dpi=150)
+
+    mock_pix = Mock()
+    mock_pix.width = 100
+    mock_pix.height = 100
+    mock_pix.samples = b"\x00" * (100 * 100 * 3)
+
+    mock_page = Mock()
+    mock_page.get_pixmap.return_value = mock_pix
+
+    mock_doc = MagicMock()
+    mock_doc.__iter__ = Mock(return_value=iter([mock_page]))
+    mock_doc.close = Mock()
+
+    mock_pil_image = Mock()
+
+    with patch("fitz.open", return_value=mock_doc):
+        with patch("fitz.Matrix", return_value=Mock()):
+            with patch("PIL.Image.frombytes", return_value=mock_pil_image):
+                pages = conv._render_pages(Path("/fake/paper.pdf"))
+
+    assert len(pages) == 1
+    assert pages[0] is mock_pil_image
+    mock_doc.close.assert_called_once()

--- a/tests/unit/test_huggingface_vlm_converter.py
+++ b/tests/unit/test_huggingface_vlm_converter.py
@@ -12,10 +12,10 @@ sys.path.insert(0, str(backend_path))
 
 from app.services.huggingface_vlm_converter import HuggingFaceVLMConverter
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_converter(pages=2):
     """Return a converter with a mocked VLM service and patched _render_pages."""
@@ -29,6 +29,7 @@ def _make_converter(pages=2):
 # ---------------------------------------------------------------------------
 # convert_to_markdown
 # ---------------------------------------------------------------------------
+
 
 def test_convert_to_markdown_joins_pages_with_separator():
     conv, mock_svc, fake_imgs = _make_converter(pages=3)
@@ -57,18 +58,20 @@ def test_convert_to_markdown_passes_extract_prompt():
 
     call_kwargs = mock_svc.extract_from_image.call_args[1]
     assert "prompt" in call_kwargs
-    assert "extraction" in call_kwargs["prompt"].lower() or "extract" in call_kwargs["prompt"].lower()
+    assert (
+        "extraction" in call_kwargs["prompt"].lower()
+        or "extract" in call_kwargs["prompt"].lower()
+    )
 
 
 # ---------------------------------------------------------------------------
 # extract_metadata
 # ---------------------------------------------------------------------------
 
+
 def test_extract_metadata_parses_valid_json():
     conv, mock_svc, _ = _make_converter(pages=1)
-    mock_svc.extract_from_image.return_value = (
-        '{"title": "My Paper", "authors": "Alice, Bob", "abstract": "An abstract.", "year": 2023}'
-    )
+    mock_svc.extract_from_image.return_value = '{"title": "My Paper", "authors": "Alice, Bob", "abstract": "An abstract.", "year": 2023}'
 
     meta = conv.extract_metadata(Path("/fake/paper.pdf"), "fallback")
 
@@ -129,6 +132,7 @@ def test_extract_metadata_null_year_gives_none():
 # ---------------------------------------------------------------------------
 # _render_pages (mocking fitz and PIL)
 # ---------------------------------------------------------------------------
+
 
 def test_render_pages_returns_pil_images():
     mock_service = Mock()

--- a/tests/unit/test_ollama_vlm_converter.py
+++ b/tests/unit/test_ollama_vlm_converter.py
@@ -1,0 +1,180 @@
+"""Unit tests for OllamaVLMConverter.
+
+fitz (PyMuPDF) and ollama.Client are mocked — no real PDF or Ollama needed.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.services.ollama_vlm_converter import OllamaVLMConverter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_converter(pages=2):
+    """Return a converter with a mocked Ollama client and patched _render_pages."""
+    with patch("ollama.Client"):
+        conv = OllamaVLMConverter(url="http://localhost:11434", model="llava-phi3")
+
+    mock_client = Mock()
+    conv.client = mock_client
+
+    fake_pages = [b"jpeg_bytes_%d" % i for i in range(pages)]
+    conv._render_pages = Mock(return_value=fake_pages)
+
+    return conv, mock_client, fake_pages
+
+
+# ---------------------------------------------------------------------------
+# convert_to_markdown
+# ---------------------------------------------------------------------------
+
+def test_convert_to_markdown_joins_pages_with_separator():
+    conv, mock_client, fake_pages = _make_converter(pages=3)
+    mock_client.chat.side_effect = [
+        {"message": {"content": "page1"}},
+        {"message": {"content": "page2"}},
+        {"message": {"content": "page3"}},
+    ]
+
+    result = conv.convert_to_markdown(Path("/fake/paper.pdf"))
+
+    assert result == "page1\n\n---\n\npage2\n\n---\n\npage3"
+    assert mock_client.chat.call_count == 3
+
+
+def test_convert_to_markdown_single_page():
+    conv, mock_client, _ = _make_converter(pages=1)
+    mock_client.chat.return_value = {"message": {"content": "only page"}}
+
+    result = conv.convert_to_markdown(Path("/fake/paper.pdf"))
+
+    assert result == "only page"
+
+
+def test_convert_to_markdown_sends_image_bytes():
+    conv, mock_client, fake_pages = _make_converter(pages=1)
+    mock_client.chat.return_value = {"message": {"content": "text"}}
+
+    conv.convert_to_markdown(Path("/fake/paper.pdf"))
+
+    call_kwargs = mock_client.chat.call_args[1]
+    messages = call_kwargs["messages"]
+    assert messages[0]["images"] == [fake_pages[0]]
+
+
+def test_convert_to_markdown_uses_correct_model():
+    conv, mock_client, _ = _make_converter(pages=1)
+    mock_client.chat.return_value = {"message": {"content": "text"}}
+
+    conv.convert_to_markdown(Path("/fake/paper.pdf"))
+
+    assert mock_client.chat.call_args[1]["model"] == "llava-phi3"
+
+
+# ---------------------------------------------------------------------------
+# extract_metadata
+# ---------------------------------------------------------------------------
+
+def test_extract_metadata_parses_valid_json():
+    conv, mock_client, _ = _make_converter(pages=1)
+    mock_client.chat.return_value = {
+        "message": {
+            "content": '{"title": "My Paper", "authors": "Alice, Bob", "abstract": "Great.", "year": 2024}'
+        }
+    }
+
+    meta = conv.extract_metadata(Path("/fake/paper.pdf"), "fallback")
+
+    assert meta["title"] == "My Paper"
+    assert "Alice" in meta["authors"]
+    assert "Bob" in meta["authors"]
+    assert meta["abstract"] == "Great."
+    assert meta["publication_date"] == "2024"
+
+
+def test_extract_metadata_strips_markdown_fences():
+    conv, mock_client, _ = _make_converter(pages=1)
+    mock_client.chat.return_value = {
+        "message": {
+            "content": "```json\n{\"title\": \"Wrapped\", \"authors\": \"Carol\", \"abstract\": null, \"year\": null}\n```"
+        }
+    }
+
+    meta = conv.extract_metadata(Path("/fake/paper.pdf"), "fallback")
+
+    assert meta["title"] == "Wrapped"
+
+
+def test_extract_metadata_falls_back_on_invalid_json():
+    conv, mock_client, _ = _make_converter(pages=1)
+    mock_client.chat.return_value = {"message": {"content": "not json"}}
+
+    meta = conv.extract_metadata(Path("/fake/paper.pdf"), "my_fallback")
+
+    assert meta["title"] == "my_fallback"
+    assert meta["authors"] == []
+    assert meta["abstract"] is None
+    assert meta["publication_date"] is None
+
+
+def test_extract_metadata_no_pages_returns_fallback():
+    with patch("ollama.Client"):
+        conv = OllamaVLMConverter()
+    mock_client = Mock()
+    conv.client = mock_client
+    conv._render_pages = Mock(return_value=[])
+
+    meta = conv.extract_metadata(Path("/fake/empty.pdf"), "empty_fallback")
+
+    assert meta["title"] == "empty_fallback"
+    mock_client.chat.assert_not_called()
+
+
+def test_extract_metadata_only_uses_first_page():
+    conv, mock_client, fake_pages = _make_converter(pages=3)
+    mock_client.chat.return_value = {
+        "message": {"content": '{"title": "T", "authors": "", "abstract": null, "year": null}'}
+    }
+
+    conv.extract_metadata(Path("/fake/paper.pdf"), "fallback")
+
+    assert mock_client.chat.call_count == 1
+    sent_images = mock_client.chat.call_args[1]["messages"][0]["images"]
+    assert sent_images == [fake_pages[0]]
+
+
+# ---------------------------------------------------------------------------
+# _render_pages (mocking fitz)
+# ---------------------------------------------------------------------------
+
+def test_render_pages_returns_jpeg_bytes():
+    with patch("ollama.Client"):
+        conv = OllamaVLMConverter(dpi=150)
+
+    fake_jpeg = b"\xff\xd8\xff"  # minimal JPEG header bytes
+
+    mock_pix = Mock()
+    mock_pix.tobytes.return_value = fake_jpeg
+
+    mock_page = Mock()
+    mock_page.get_pixmap.return_value = mock_pix
+
+    mock_doc = MagicMock()
+    mock_doc.__iter__ = Mock(return_value=iter([mock_page]))
+    mock_doc.close = Mock()
+
+    with patch("fitz.open", return_value=mock_doc):
+        with patch("fitz.Matrix", return_value=Mock()):
+            pages = conv._render_pages(Path("/fake/paper.pdf"))
+
+    assert len(pages) == 1
+    assert pages[0] == fake_jpeg
+    mock_pix.tobytes.assert_called_once_with("jpeg")
+    mock_doc.close.assert_called_once()

--- a/tests/unit/test_ollama_vlm_converter.py
+++ b/tests/unit/test_ollama_vlm_converter.py
@@ -12,10 +12,10 @@ sys.path.insert(0, str(backend_path))
 
 from app.services.ollama_vlm_converter import OllamaVLMConverter
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_converter(pages=2):
     """Return a converter with a mocked Ollama client and patched _render_pages."""
@@ -34,6 +34,7 @@ def _make_converter(pages=2):
 # ---------------------------------------------------------------------------
 # convert_to_markdown
 # ---------------------------------------------------------------------------
+
 
 def test_convert_to_markdown_joins_pages_with_separator():
     conv, mock_client, fake_pages = _make_converter(pages=3)
@@ -82,6 +83,7 @@ def test_convert_to_markdown_uses_correct_model():
 # extract_metadata
 # ---------------------------------------------------------------------------
 
+
 def test_extract_metadata_parses_valid_json():
     conv, mock_client, _ = _make_converter(pages=1)
     mock_client.chat.return_value = {
@@ -103,7 +105,7 @@ def test_extract_metadata_strips_markdown_fences():
     conv, mock_client, _ = _make_converter(pages=1)
     mock_client.chat.return_value = {
         "message": {
-            "content": "```json\n{\"title\": \"Wrapped\", \"authors\": \"Carol\", \"abstract\": null, \"year\": null}\n```"
+            "content": '```json\n{"title": "Wrapped", "authors": "Carol", "abstract": null, "year": null}\n```'
         }
     }
 
@@ -140,7 +142,9 @@ def test_extract_metadata_no_pages_returns_fallback():
 def test_extract_metadata_only_uses_first_page():
     conv, mock_client, fake_pages = _make_converter(pages=3)
     mock_client.chat.return_value = {
-        "message": {"content": '{"title": "T", "authors": "", "abstract": null, "year": null}'}
+        "message": {
+            "content": '{"title": "T", "authors": "", "abstract": null, "year": null}'
+        }
     }
 
     conv.extract_metadata(Path("/fake/paper.pdf"), "fallback")
@@ -153,6 +157,7 @@ def test_extract_metadata_only_uses_first_page():
 # ---------------------------------------------------------------------------
 # _render_pages (mocking fitz)
 # ---------------------------------------------------------------------------
+
 
 def test_render_pages_returns_jpeg_bytes():
     with patch("ollama.Client"):

--- a/tests/unit/test_rag_huggingface.py
+++ b/tests/unit/test_rag_huggingface.py
@@ -1,0 +1,104 @@
+"""Unit tests for the HuggingFace LLM branch in app.api.rag.
+
+Tests _get_llm_service and _get_llm_info for type: huggingface config,
+without starting FastAPI or connecting to Qdrant/Ollama.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.api.rag import _get_llm_info, _get_llm_service
+
+
+# ---------------------------------------------------------------------------
+# _get_llm_info
+# ---------------------------------------------------------------------------
+
+def test_get_llm_info_huggingface_uses_config_model():
+    config = {
+        "models": {
+            "llm": {
+                "type": "huggingface",
+                "hf_model": "Qwen/Qwen2.5-7B-Instruct",
+            }
+        }
+    }
+    info = _get_llm_info(config)
+    assert info["provider"] == "huggingface"
+    assert info["model"] == "Qwen/Qwen2.5-7B-Instruct"
+
+
+def test_get_llm_info_huggingface_falls_back_to_settings():
+    config = {"models": {"llm": {"type": "huggingface"}}}
+    info = _get_llm_info(config)
+    assert info["provider"] == "huggingface"
+    # Should be the settings default, whatever it is
+    assert isinstance(info["model"], str)
+    assert len(info["model"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# _get_llm_service
+# ---------------------------------------------------------------------------
+
+def test_get_llm_service_huggingface_returns_huggingface_service():
+    config = {
+        "models": {
+            "llm": {
+                "type": "huggingface",
+                "hf_model": "Qwen/Qwen2.5-3B-Instruct",
+                "hf_embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+            }
+        }
+    }
+
+    mock_hf_instance = Mock()
+    mock_hf_class = Mock(return_value=mock_hf_instance)
+
+    with patch("app.api.rag.HuggingFaceService", mock_hf_class, create=True):
+        with patch.dict("sys.modules", {"app.services.huggingface_service": Mock(HuggingFaceService=mock_hf_class)}):
+            # Patch the import inside the function
+            with patch("builtins.__import__", wraps=__import__) as mock_import:
+                def side_effect(name, *args, **kwargs):
+                    if name == "app.services.huggingface_service":
+                        m = Mock()
+                        m.HuggingFaceService = mock_hf_class
+                        return m
+                    return __import__(name, *args, **kwargs)
+                mock_import.side_effect = side_effect
+                service = _get_llm_service(config)
+
+    assert service is mock_hf_instance
+    mock_hf_class.assert_called_once_with(
+        model_id="Qwen/Qwen2.5-3B-Instruct",
+        embedding_model_id="sentence-transformers/all-MiniLM-L6-v2",
+    )
+
+
+def test_get_llm_service_huggingface_uses_settings_defaults():
+    """When hf_model/hf_embedding_model are absent, settings defaults are used."""
+    config = {"models": {"llm": {"type": "huggingface"}}}
+
+    mock_hf_instance = Mock()
+    mock_hf_class = Mock(return_value=mock_hf_instance)
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "app.services.huggingface_service":
+            m = Mock()
+            m.HuggingFaceService = mock_hf_class
+            return m
+        return __import__(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=_fake_import):
+        service = _get_llm_service(config)
+
+    assert service is mock_hf_instance
+    _, call_kwargs = mock_hf_class.call_args
+    assert "model_id" in call_kwargs
+    assert "embedding_model_id" in call_kwargs

--- a/tests/unit/test_rag_huggingface.py
+++ b/tests/unit/test_rag_huggingface.py
@@ -8,17 +8,15 @@ import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import pytest
-
 backend_path = Path(__file__).parent.parent.parent / "backend"
 sys.path.insert(0, str(backend_path))
 
 from app.api.rag import _get_llm_info, _get_llm_service
 
-
 # ---------------------------------------------------------------------------
 # _get_llm_info
 # ---------------------------------------------------------------------------
+
 
 def test_get_llm_info_huggingface_uses_config_model():
     config = {
@@ -47,6 +45,7 @@ def test_get_llm_info_huggingface_falls_back_to_settings():
 # _get_llm_service
 # ---------------------------------------------------------------------------
 
+
 def test_get_llm_service_huggingface_returns_huggingface_service():
     config = {
         "models": {
@@ -62,15 +61,24 @@ def test_get_llm_service_huggingface_returns_huggingface_service():
     mock_hf_class = Mock(return_value=mock_hf_instance)
 
     with patch("app.api.rag.HuggingFaceService", mock_hf_class, create=True):
-        with patch.dict("sys.modules", {"app.services.huggingface_service": Mock(HuggingFaceService=mock_hf_class)}):
+        with patch.dict(
+            "sys.modules",
+            {
+                "app.services.huggingface_service": Mock(
+                    HuggingFaceService=mock_hf_class
+                )
+            },
+        ):
             # Patch the import inside the function
             with patch("builtins.__import__", wraps=__import__) as mock_import:
+
                 def side_effect(name, *args, **kwargs):
                     if name == "app.services.huggingface_service":
                         m = Mock()
                         m.HuggingFaceService = mock_hf_class
                         return m
                     return __import__(name, *args, **kwargs)
+
                 mock_import.side_effect = side_effect
                 service = _get_llm_service(config)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2669,6 +2669,13 @@ docs = [
     { name = "sphinx" },
     { name = "sphinx-autodoc-typehints" },
 ]
+huggingface = [
+    { name = "accelerate" },
+    { name = "pillow" },
+    { name = "sentencepiece" },
+    { name = "torch" },
+    { name = "transformers" },
+]
 publishing = [
     { name = "build" },
     { name = "twine" },
@@ -2676,6 +2683,7 @@ publishing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", marker = "extra == 'huggingface'", specifier = ">=0.27" },
     { name = "anthropic", marker = "extra == 'api'", specifier = ">=0.18.0" },
     { name = "build", marker = "extra == 'publishing'", specifier = ">=1.0" },
     { name = "docling", specifier = ">=2.74.0" },
@@ -2689,6 +2697,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.9" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0" },
     { name = "ollama", specifier = ">=0.1.0" },
+    { name = "pillow", marker = "extra == 'huggingface'", specifier = ">=10.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0" },
     { name = "pydantic", specifier = ">=2.6.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
@@ -2700,13 +2709,16 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdrant-client", specifier = ">=1.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "sentencepiece", marker = "extra == 'huggingface'", specifier = ">=0.1" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'", specifier = ">=1.25" },
+    { name = "torch", marker = "extra == 'huggingface'", specifier = ">=2.0" },
+    { name = "transformers", marker = "extra == 'huggingface'", specifier = ">=4.45" },
     { name = "twine", marker = "extra == 'publishing'", specifier = ">=5.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27.0" },
 ]
-provides-extras = ["dev", "api", "docs", "publishing"]
+provides-extras = ["dev", "api", "huggingface", "docs", "publishing"]
 
 [[package]]
 name = "pre-commit"
@@ -3856,6 +3868,54 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/96/c418c322730b385e81d4ab462e68dd48bb2dbda4d8efa17cad2ca468d9ac/semchunk-2.2.2.tar.gz", hash = "sha256:940e89896e64eeb01de97ba60f51c8c7b96c6a3951dfcf574f25ce2146752f52", size = 12271, upload-time = "2024-12-17T22:54:30.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/84/94ca7896c7df20032bcb09973e9a4d14c222507c0aadf22e89fa76bb0a04/semchunk-2.2.2-py3-none-any.whl", hash = "sha256:94ca19020c013c073abdfd06d79a7c13637b91738335f3b8cdb5655ee7cc94d2", size = 10271, upload-time = "2024-12-17T22:54:27.689Z" },
+]
+
+[[package]]
+name = "sentencepiece"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/15/2e7a025fc62d764b151ae6d0f2a92f8081755ebe8d4a64099accc6f77ba6/sentencepiece-0.2.1.tar.gz", hash = "sha256:8138cec27c2f2282f4a34d9a016e3374cd40e5c6e9cb335063db66a0a3b71fad", size = 3228515, upload-time = "2025-08-12T07:00:51.718Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/be/32ce495aa1d0e0c323dcb1ba87096037358edee539cac5baf8755a6bd396/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57cae326c8727de58c85977b175af132a7138d84c764635d7e71bbee7e774133", size = 1943152, upload-time = "2025-08-12T06:59:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/88/7e/ff23008899a58678e98c6ff592bf4d368eee5a71af96d0df6b38a039dd4f/sentencepiece-0.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:56dd39a3c4d6493db3cdca7e8cc68c6b633f0d4195495cbadfcf5af8a22d05a6", size = 1325651, upload-time = "2025-08-12T06:59:41.536Z" },
+    { url = "https://files.pythonhosted.org/packages/19/84/42eb3ce4796777a1b5d3699dfd4dca85113e68b637f194a6c8d786f16a04/sentencepiece-0.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d9381351182ff9888cc80e41c632e7e274b106f450de33d67a9e8f6043da6f76", size = 1253645, upload-time = "2025-08-12T06:59:42.903Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fa/d3d5ebcba3cb9e6d3775a096251860c41a6bc53a1b9461151df83fe93255/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99f955df238021bf11f0fc37cdb54fd5e5b5f7fd30ecc3d93fb48b6815437167", size = 1316273, upload-time = "2025-08-12T06:59:44.476Z" },
+    { url = "https://files.pythonhosted.org/packages/04/88/14f2f4a2b922d8b39be45bf63d79e6cd3a9b2f248b2fcb98a69b12af12f5/sentencepiece-0.2.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cdfecef430d985f1c2bcbfff3defd1d95dae876fbd0173376012d2d7d24044b", size = 1387881, upload-time = "2025-08-12T06:59:46.09Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/b8/903e5ccb77b4ef140605d5d71b4f9e0ad95d456d6184688073ed11712809/sentencepiece-0.2.1-cp312-cp312-win32.whl", hash = "sha256:a483fd29a34c3e34c39ac5556b0a90942bec253d260235729e50976f5dba1068", size = 999540, upload-time = "2025-08-12T06:59:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/81/92df5673c067148c2545b1bfe49adfd775bcc3a169a047f5a0e6575ddaca/sentencepiece-0.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:4cdc7c36234fda305e85c32949c5211faaf8dd886096c7cea289ddc12a2d02de", size = 1054671, upload-time = "2025-08-12T06:59:49.895Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/02/c5e3bc518655d714622bec87d83db9cdba1cd0619a4a04e2109751c4f47f/sentencepiece-0.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:daeb5e9e9fcad012324807856113708614d534f596d5008638eb9b40112cd9e4", size = 1033923, upload-time = "2025-08-12T06:59:51.952Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4a/85fbe1706d4d04a7e826b53f327c4b80f849cf1c7b7c5e31a20a97d8f28b/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dcd8161eee7b41aae57ded06272905dbd680a0a04b91edd0f64790c796b2f706", size = 1943150, upload-time = "2025-08-12T06:59:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/4cfb393e287509fc2155480b9d184706ef8d9fa8cbf5505d02a5792bf220/sentencepiece-0.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c6c8f42949f419ff8c7e9960dbadcfbc982d7b5efc2f6748210d3dd53a7de062", size = 1325651, upload-time = "2025-08-12T06:59:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/de/5a007fb53b1ab0aafc69d11a5a3dd72a289d5a3e78dcf2c3a3d9b14ffe93/sentencepiece-0.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:097f3394e99456e9e4efba1737c3749d7e23563dd1588ce71a3d007f25475fff", size = 1253641, upload-time = "2025-08-12T06:59:56.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d2/f552be5928105588f4f4d66ee37dd4c61460d8097e62d0e2e0eec41bc61d/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7b670879c370d350557edabadbad1f6561a9e6968126e6debca4029e5547820", size = 1316271, upload-time = "2025-08-12T06:59:58.109Z" },
+    { url = "https://files.pythonhosted.org/packages/96/df/0cfe748ace5485be740fed9476dee7877f109da32ed0d280312c94ec259f/sentencepiece-0.2.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7f0fd2f2693309e6628aeeb2e2faf6edd221134dfccac3308ca0de01f8dab47", size = 1387882, upload-time = "2025-08-12T07:00:00.701Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dd/f7774d42a881ced8e1739f393ab1e82ece39fc9abd4779e28050c2e975b5/sentencepiece-0.2.1-cp313-cp313-win32.whl", hash = "sha256:92b3816aa2339355fda2c8c4e021a5de92180b00aaccaf5e2808972e77a4b22f", size = 999541, upload-time = "2025-08-12T07:00:02.709Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e9/932b9eae6fd7019548321eee1ab8d5e3b3d1294df9d9a0c9ac517c7b636d/sentencepiece-0.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:10ed3dab2044c47f7a2e7b4969b0c430420cdd45735d78c8f853191fa0e3148b", size = 1054669, upload-time = "2025-08-12T07:00:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/3a/76488a00ea7d6931689cda28726a1447d66bf1a4837943489314593d5596/sentencepiece-0.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac650534e2251083c5f75dde4ff28896ce7c8904133dc8fef42780f4d5588fcd", size = 1033922, upload-time = "2025-08-12T07:00:06.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b6/08fe2ce819e02ccb0296f4843e3f195764ce9829cbda61b7513f29b95718/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:8dd4b477a7b069648d19363aad0cab9bad2f4e83b2d179be668efa672500dc94", size = 1946052, upload-time = "2025-08-12T07:00:08.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d9/1ea0e740591ff4c6fc2b6eb1d7510d02f3fb885093f19b2f3abd1363b402/sentencepiece-0.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0c0f672da370cc490e4c59d89e12289778310a0e71d176c541e4834759e1ae07", size = 1327408, upload-time = "2025-08-12T07:00:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7e/1fb26e8a21613f6200e1ab88824d5d203714162cf2883248b517deb500b7/sentencepiece-0.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ad8493bea8432dae8d6830365352350f3b4144415a1d09c4c8cb8d30cf3b6c3c", size = 1254857, upload-time = "2025-08-12T07:00:11.021Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/85/c72fd1f3c7a6010544d6ae07f8ddb38b5e2a7e33bd4318f87266c0bbafbf/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b81a24733726e3678d2db63619acc5a8dccd074f7aa7a54ecd5ca33ca6d2d596", size = 1315722, upload-time = "2025-08-12T07:00:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e8/661e5bd82a8aa641fd6c1020bd0e890ef73230a2b7215ddf9c8cd8e941c2/sentencepiece-0.2.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0a81799d0a68d618e89063fb423c3001a034c893069135ffe51fee439ae474d6", size = 1387452, upload-time = "2025-08-12T07:00:15.088Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5e/ae66c361023a470afcbc1fbb8da722c72ea678a2fcd9a18f1a12598c7501/sentencepiece-0.2.1-cp313-cp313t-win32.whl", hash = "sha256:89a3ea015517c42c0341d0d962f3e6aaf2cf10d71b1932d475c44ba48d00aa2b", size = 1002501, upload-time = "2025-08-12T07:00:16.966Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/03/d332828c4ff764e16c1b56c2c8f9a33488bbe796b53fb6b9c4205ddbf167/sentencepiece-0.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:33f068c9382dc2e7c228eedfd8163b52baa86bb92f50d0488bf2b7da7032e484", size = 1057555, upload-time = "2025-08-12T07:00:18.573Z" },
+    { url = "https://files.pythonhosted.org/packages/88/14/5aee0bf0864df9bd82bd59e7711362908e4935e3f9cdc1f57246b5d5c9b9/sentencepiece-0.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:b3616ad246f360e52c85781e47682d31abfb6554c779e42b65333d4b5f44ecc0", size = 1036042, upload-time = "2025-08-12T07:00:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9c/89eb8b2052f720a612478baf11c8227dcf1dc28cd4ea4c0c19506b5af2a2/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:5d0350b686c320068702116276cfb26c066dc7e65cfef173980b11bb4d606719", size = 1943147, upload-time = "2025-08-12T07:00:21.809Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0b/a1432bc87f97c2ace36386ca23e8bd3b91fb40581b5e6148d24b24186419/sentencepiece-0.2.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c7f54a31cde6fa5cb030370566f68152a742f433f8d2be458463d06c208aef33", size = 1325624, upload-time = "2025-08-12T07:00:23.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/99/bbe054ebb5a5039457c590e0a4156ed073fb0fe9ce4f7523404dd5b37463/sentencepiece-0.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c83b85ab2d6576607f31df77ff86f28182be4a8de6d175d2c33ca609925f5da1", size = 1253670, upload-time = "2025-08-12T07:00:24.69Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ad/d5c7075f701bd97971d7c2ac2904f227566f51ef0838dfbdfdccb58cd212/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1855f57db07b51fb51ed6c9c452f570624d2b169b36f0f79ef71a6e6c618cd8b", size = 1316247, upload-time = "2025-08-12T07:00:26.435Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/03/35fbe5f3d9a7435eebd0b473e09584bd3cc354ce118b960445b060d33781/sentencepiece-0.2.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01e6912125cb45d3792f530a4d38f8e21bf884d6b4d4ade1b2de5cf7a8d2a52b", size = 1387894, upload-time = "2025-08-12T07:00:28.339Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/aa/956ef729aafb6c8f9c443104c9636489093bb5c61d6b90fc27aa1a865574/sentencepiece-0.2.1-cp314-cp314-win32.whl", hash = "sha256:c415c9de1447e0a74ae3fdb2e52f967cb544113a3a5ce3a194df185cbc1f962f", size = 1096698, upload-time = "2025-08-12T07:00:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/fe400d8836952cc535c81a0ce47dc6875160e5fedb71d2d9ff0e9894c2a6/sentencepiece-0.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:881b2e44b14fc19feade3cbed314be37de639fc415375cefaa5bc81a4be137fd", size = 1155115, upload-time = "2025-08-12T07:00:32.865Z" },
+    { url = "https://files.pythonhosted.org/packages/32/89/047921cf70f36c7b6b6390876b2399b3633ab73b8d0cb857e5a964238941/sentencepiece-0.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:2005242a16d2dc3ac5fe18aa7667549134d37854823df4c4db244752453b78a8", size = 1133890, upload-time = "2025-08-12T07:00:34.763Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/11/5b414b9fae6255b5fb1e22e2ed3dc3a72d3a694e5703910e640ac78346bb/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:a19adcec27c524cb7069a1c741060add95f942d1cbf7ad0d104dffa0a7d28a2b", size = 1946081, upload-time = "2025-08-12T07:00:36.97Z" },
+    { url = "https://files.pythonhosted.org/packages/77/eb/7a5682bb25824db8545f8e5662e7f3e32d72a508fdce086029d89695106b/sentencepiece-0.2.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:e37e4b4c4a11662b5db521def4e44d4d30ae69a1743241412a93ae40fdcab4bb", size = 1327406, upload-time = "2025-08-12T07:00:38.669Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b0/811dae8fb9f2784e138785d481469788f2e0d0c109c5737372454415f55f/sentencepiece-0.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:477c81505db072b3ab627e7eab972ea1025331bd3a92bacbf798df2b75ea86ec", size = 1254846, upload-time = "2025-08-12T07:00:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/23/195b2e7ec85ebb6a547969f60b723c7aca5a75800ece6cc3f41da872d14e/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:010f025a544ef770bb395091d57cb94deb9652d8972e0d09f71d85d5a0816c8c", size = 1315721, upload-time = "2025-08-12T07:00:42.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/aa/553dbe4178b5f23eb28e59393dddd64186178b56b81d9b8d5c3ff1c28395/sentencepiece-0.2.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:733e59ff1794d26db706cd41fc2d7ca5f6c64a820709cb801dc0ea31780d64ab", size = 1387458, upload-time = "2025-08-12T07:00:44.56Z" },
+    { url = "https://files.pythonhosted.org/packages/66/7c/08ff0012507297a4dd74a5420fdc0eb9e3e80f4e88cab1538d7f28db303d/sentencepiece-0.2.1-cp314-cp314t-win32.whl", hash = "sha256:d3233770f78e637dc8b1fda2cd7c3b99ec77e7505041934188a4e7fe751de3b0", size = 1099765, upload-time = "2025-08-12T07:00:46.058Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d5/2a69e1ce15881beb9ddfc7e3f998322f5cedcd5e4d244cb74dade9441663/sentencepiece-0.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e4366c97b68218fd30ea72d70c525e6e78a6c0a88650f57ac4c43c63b234a9d", size = 1157807, upload-time = "2025-08-12T07:00:47.673Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/16/54f611fcfc2d1c46cbe3ec4169780b2cfa7cf63708ef2b71611136db7513/sentencepiece-0.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:105e36e75cbac1292642045458e8da677b2342dcd33df503e640f0b457cb6751", size = 1136264, upload-time = "2025-08-12T07:00:49.485Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This branch adds two main functionalities:
- `HuggingFaceService` to directly load published models in HF, even if they are not available in Ollama. It also includes handling multimodal responses
- `HuggingFaceVLMConverter`: both for PDF preprocessing and extraction (Bypass OCR).
- `OllamaVLMConverter`: both for PDF preprocessing and extraction (Bypass OCR).